### PR TITLE
Rename "Soldered Wire Connector" to "Generic Connector"

### DIFF
--- a/cmp/00c36da8-e22b-43a1-9a87-c3a67e863f49/component.lp
+++ b/cmp/00c36da8-e22b-43a1-9a87-c3a67e863f49/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 00c36da8-e22b-43a1-9a87-c3a67e863f49
- (name "Soldered Wire Connector 1x27")
+ (name "Generic Connector 1x27")
  (description "A 1x27 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x27, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/05d0bce0-c94c-4fec-bca2-2c2b60490c01/component.lp
+++ b/cmp/05d0bce0-c94c-4fec-bca2-2c2b60490c01/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 05d0bce0-c94c-4fec-bca2-2c2b60490c01
- (name "Soldered Wire Connector 1x4")
+ (name "Generic Connector 1x4")
  (description "A 1x4 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x4, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/08e75b52-b5cb-42eb-b523-1a412700e1ef/component.lp
+++ b/cmp/08e75b52-b5cb-42eb-b523-1a412700e1ef/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 08e75b52-b5cb-42eb-b523-1a412700e1ef
- (name "Soldered Wire Connector 1x35")
+ (name "Generic Connector 1x35")
  (description "A 1x35 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x35, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/0f32efe5-bb13-45bd-bc0e-f5782560a904/component.lp
+++ b/cmp/0f32efe5-bb13-45bd-bc0e-f5782560a904/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 0f32efe5-bb13-45bd-bc0e-f5782560a904
- (name "Soldered Wire Connector 1x16")
+ (name "Generic Connector 1x16")
  (description "A 1x16 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x16, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/10049a6b-195c-4e15-b316-0e33b9c825e8/component.lp
+++ b/cmp/10049a6b-195c-4e15-b316-0e33b9c825e8/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 10049a6b-195c-4e15-b316-0e33b9c825e8
- (name "Soldered Wire Connector 1x20")
+ (name "Generic Connector 1x20")
  (description "A 1x20 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x20, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/1d489550-67ef-4785-b5cb-3f907d3f41b5/component.lp
+++ b/cmp/1d489550-67ef-4785-b5cb-3f907d3f41b5/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 1d489550-67ef-4785-b5cb-3f907d3f41b5
- (name "Soldered Wire Connector 1x17")
+ (name "Generic Connector 1x17")
  (description "A 1x17 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x17, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/27dfbb92-c02a-4422-a447-e33846e6ff8c/component.lp
+++ b/cmp/27dfbb92-c02a-4422-a447-e33846e6ff8c/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 27dfbb92-c02a-4422-a447-e33846e6ff8c
- (name "Soldered Wire Connector 1x13")
+ (name "Generic Connector 1x13")
  (description "A 1x13 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x13, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/28af7310-fc24-4428-817d-eb89ca555e2a/component.lp
+++ b/cmp/28af7310-fc24-4428-817d-eb89ca555e2a/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 28af7310-fc24-4428-817d-eb89ca555e2a
- (name "Soldered Wire Connector 1x37")
+ (name "Generic Connector 1x37")
  (description "A 1x37 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x37, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/30288ebf-082f-4de5-8ab8-5cc8c7e0790b/component.lp
+++ b/cmp/30288ebf-082f-4de5-8ab8-5cc8c7e0790b/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 30288ebf-082f-4de5-8ab8-5cc8c7e0790b
- (name "Soldered Wire Connector 1x26")
+ (name "Generic Connector 1x26")
  (description "A 1x26 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x26, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/3422d4e3-521a-4828-b299-eb0898b45cb7/component.lp
+++ b/cmp/3422d4e3-521a-4828-b299-eb0898b45cb7/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 3422d4e3-521a-4828-b299-eb0898b45cb7
- (name "Soldered Wire Connector 1x12")
+ (name "Generic Connector 1x12")
  (description "A 1x12 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x12, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/53e9d8e2-3393-4ebe-892a-e217384093d4/component.lp
+++ b/cmp/53e9d8e2-3393-4ebe-892a-e217384093d4/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 53e9d8e2-3393-4ebe-892a-e217384093d4
- (name "Soldered Wire Connector 1x28")
+ (name "Generic Connector 1x28")
  (description "A 1x28 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x28, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/62495a4b-f295-4c32-893f-5ff3d162a549/component.lp
+++ b/cmp/62495a4b-f295-4c32-893f-5ff3d162a549/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 62495a4b-f295-4c32-893f-5ff3d162a549
- (name "Soldered Wire Connector 1x30")
+ (name "Generic Connector 1x30")
  (description "A 1x30 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x30, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/62a92303-32ab-42b1-baf3-99b29d56aae6/component.lp
+++ b/cmp/62a92303-32ab-42b1-baf3-99b29d56aae6/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 62a92303-32ab-42b1-baf3-99b29d56aae6
- (name "Soldered Wire Connector 1x40")
+ (name "Generic Connector 1x40")
  (description "A 1x40 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x40, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/6c45b38d-a264-4c8d-a60a-35e211af0264/component.lp
+++ b/cmp/6c45b38d-a264-4c8d-a60a-35e211af0264/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 6c45b38d-a264-4c8d-a60a-35e211af0264
- (name "Soldered Wire Connector 1x18")
+ (name "Generic Connector 1x18")
  (description "A 1x18 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x18, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/7152245d-e02b-4a4d-a618-0f2039c09fcc/component.lp
+++ b/cmp/7152245d-e02b-4a4d-a618-0f2039c09fcc/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 7152245d-e02b-4a4d-a618-0f2039c09fcc
- (name "Soldered Wire Connector 1x29")
+ (name "Generic Connector 1x29")
  (description "A 1x29 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x29, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/78fdb0ac-153f-48d5-915a-f5d7b4aeb4c1/component.lp
+++ b/cmp/78fdb0ac-153f-48d5-915a-f5d7b4aeb4c1/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 78fdb0ac-153f-48d5-915a-f5d7b4aeb4c1
- (name "Soldered Wire Connector 1x21")
+ (name "Generic Connector 1x21")
  (description "A 1x21 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x21, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/8847073b-197d-4a6c-9c12-3a0b37b17f5d/component.lp
+++ b/cmp/8847073b-197d-4a6c-9c12-3a0b37b17f5d/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 8847073b-197d-4a6c-9c12-3a0b37b17f5d
- (name "Soldered Wire Connector 1x24")
+ (name "Generic Connector 1x24")
  (description "A 1x24 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x24, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/90d521c3-9d9b-480b-88fd-c4c04c656b7b/component.lp
+++ b/cmp/90d521c3-9d9b-480b-88fd-c4c04c656b7b/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 90d521c3-9d9b-480b-88fd-c4c04c656b7b
- (name "Soldered Wire Connector 1x22")
+ (name "Generic Connector 1x22")
  (description "A 1x22 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x22, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/929ca811-b92b-433d-9013-4523f70ccb2c/component.lp
+++ b/cmp/929ca811-b92b-433d-9013-4523f70ccb2c/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 929ca811-b92b-433d-9013-4523f70ccb2c
- (name "Soldered Wire Connector 1x11")
+ (name "Generic Connector 1x11")
  (description "A 1x11 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x11, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/929ec75d-fb4e-496d-be89-4b1df4d20ee1/component.lp
+++ b/cmp/929ec75d-fb4e-496d-be89-4b1df4d20ee1/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 929ec75d-fb4e-496d-be89-4b1df4d20ee1
- (name "Soldered Wire Connector 1x31")
+ (name "Generic Connector 1x31")
  (description "A 1x31 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x31, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/93b66d7c-86b4-48ca-a4ed-f6de5de4b74d/component.lp
+++ b/cmp/93b66d7c-86b4-48ca-a4ed-f6de5de4b74d/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component 93b66d7c-86b4-48ca-a4ed-f6de5de4b74d
- (name "Soldered Wire Connector 1x5")
+ (name "Generic Connector 1x5")
  (description "A 1x5 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x5, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/a19781b6-0837-4f7c-9be3-a62431b956cc/component.lp
+++ b/cmp/a19781b6-0837-4f7c-9be3-a62431b956cc/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component a19781b6-0837-4f7c-9be3-a62431b956cc
- (name "Soldered Wire Connector 1x38")
+ (name "Generic Connector 1x38")
  (description "A 1x38 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x38, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/a42f7217-8445-419b-b665-470f6ecffba0/component.lp
+++ b/cmp/a42f7217-8445-419b-b665-470f6ecffba0/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component a42f7217-8445-419b-b665-470f6ecffba0
- (name "Soldered Wire Connector 1x6")
+ (name "Generic Connector 1x6")
  (description "A 1x6 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x6, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/a85e2027-9d88-48cc-b0e6-1e8e939771a2/component.lp
+++ b/cmp/a85e2027-9d88-48cc-b0e6-1e8e939771a2/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component a85e2027-9d88-48cc-b0e6-1e8e939771a2
- (name "Soldered Wire Connector 1x14")
+ (name "Generic Connector 1x14")
  (description "A 1x14 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x14, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/af29ef7a-d944-4ad8-8c62-8efce6555305/component.lp
+++ b/cmp/af29ef7a-d944-4ad8-8c62-8efce6555305/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component af29ef7a-d944-4ad8-8c62-8efce6555305
- (name "Soldered Wire Connector 1x23")
+ (name "Generic Connector 1x23")
  (description "A 1x23 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x23, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/b9804593-8d2d-46bf-a468-7e5d85eee9bc/component.lp
+++ b/cmp/b9804593-8d2d-46bf-a468-7e5d85eee9bc/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component b9804593-8d2d-46bf-a468-7e5d85eee9bc
- (name "Soldered Wire Connector 1x7")
+ (name "Generic Connector 1x7")
  (description "A 1x7 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x7, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/b9f6a06e-ed79-4d8d-8f7c-0aa11e2a2154/component.lp
+++ b/cmp/b9f6a06e-ed79-4d8d-8f7c-0aa11e2a2154/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component b9f6a06e-ed79-4d8d-8f7c-0aa11e2a2154
- (name "Soldered Wire Connector 1x39")
+ (name "Generic Connector 1x39")
  (description "A 1x39 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x39, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/be538d89-be57-4eeb-8e53-de80db425012/component.lp
+++ b/cmp/be538d89-be57-4eeb-8e53-de80db425012/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component be538d89-be57-4eeb-8e53-de80db425012
- (name "Soldered Wire Connector 1x32")
+ (name "Generic Connector 1x32")
  (description "A 1x32 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x32, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/c986f4e8-8546-4aa9-939a-035fce71b708/component.lp
+++ b/cmp/c986f4e8-8546-4aa9-939a-035fce71b708/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component c986f4e8-8546-4aa9-939a-035fce71b708
- (name "Soldered Wire Connector 1x19")
+ (name "Generic Connector 1x19")
  (description "A 1x19 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x19, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/ca90eab3-1e9b-4f95-ae75-0ba18b98c25d/component.lp
+++ b/cmp/ca90eab3-1e9b-4f95-ae75-0ba18b98c25d/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component ca90eab3-1e9b-4f95-ae75-0ba18b98c25d
- (name "Soldered Wire Connector 1x10")
+ (name "Generic Connector 1x10")
  (description "A 1x10 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x10, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/ce2ea95f-dbd2-432e-a6a6-6c20043f6d7e/component.lp
+++ b/cmp/ce2ea95f-dbd2-432e-a6a6-6c20043f6d7e/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component ce2ea95f-dbd2-432e-a6a6-6c20043f6d7e
- (name "Soldered Wire Connector 1x3")
+ (name "Generic Connector 1x3")
  (description "A 1x3 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x3, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/d6c65753-fe01-4aec-a67d-19f2a5a151f6/component.lp
+++ b/cmp/d6c65753-fe01-4aec-a67d-19f2a5a151f6/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component d6c65753-fe01-4aec-a67d-19f2a5a151f6
- (name "Soldered Wire Connector 1x34")
+ (name "Generic Connector 1x34")
  (description "A 1x34 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x34, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/d7f69f0c-f485-45f0-ad70-6b4858a3b453/component.lp
+++ b/cmp/d7f69f0c-f485-45f0-ad70-6b4858a3b453/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component d7f69f0c-f485-45f0-ad70-6b4858a3b453
- (name "Soldered Wire Connector 1x36")
+ (name "Generic Connector 1x36")
  (description "A 1x36 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x36, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/d9283379-4447-477f-99e6-0d13e321bb4a/component.lp
+++ b/cmp/d9283379-4447-477f-99e6-0d13e321bb4a/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component d9283379-4447-477f-99e6-0d13e321bb4a
- (name "Soldered Wire Connector 1x8")
+ (name "Generic Connector 1x8")
  (description "A 1x8 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x8, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/da0f5511-3d2b-45f6-ac3f-709a1576d8cd/component.lp
+++ b/cmp/da0f5511-3d2b-45f6-ac3f-709a1576d8cd/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component da0f5511-3d2b-45f6-ac3f-709a1576d8cd
- (name "Soldered Wire Connector 1x33")
+ (name "Generic Connector 1x33")
  (description "A 1x33 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x33, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/e6b8e76f-3817-4f54-8426-fc6b6a60cf8d/component.lp
+++ b/cmp/e6b8e76f-3817-4f54-8426-fc6b6a60cf8d/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component e6b8e76f-3817-4f54-8426-fc6b6a60cf8d
- (name "Soldered Wire Connector 1x25")
+ (name "Generic Connector 1x25")
  (description "A 1x25 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x25, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/f076adf2-b523-4f02-9b77-26ae1f0b515b/component.lp
+++ b/cmp/f076adf2-b523-4f02-9b77-26ae1f0b515b/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component f076adf2-b523-4f02-9b77-26ae1f0b515b
- (name "Soldered Wire Connector 1x15")
+ (name "Generic Connector 1x15")
  (description "A 1x15 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x15, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/f62feaaa-19c4-4378-b699-4528637e1107/component.lp
+++ b/cmp/f62feaaa-19c4-4378-b699-4528637e1107/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component f62feaaa-19c4-4378-b699-4528637e1107
- (name "Soldered Wire Connector 1x2")
+ (name "Generic Connector 1x2")
  (description "A 1x2 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x2, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/fbf742d9-5c74-454e-ba7b-e9afc9ded61a/component.lp
+++ b/cmp/fbf742d9-5c74-454e-ba7b-e9afc9ded61a/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component fbf742d9-5c74-454e-ba7b-e9afc9ded61a
- (name "Soldered Wire Connector 1x9")
+ (name "Generic Connector 1x9")
  (description "A 1x9 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x9, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)

--- a/cmp/ffd16aa9-3eac-4337-bb34-33ee2f4a2e01/component.lp
+++ b/cmp/ffd16aa9-3eac-4337-bb34-33ee2f4a2e01/component.lp
@@ -1,9 +1,9 @@
 (librepcb_component ffd16aa9-3eac-4337-bb34-33ee2f4a2e01
- (name "Soldered Wire Connector 1x1")
+ (name "Generic Connector 1x1")
  (description "A 1x1 soldered wire connector.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x1, connector, soldering, generic")
  (author "Danilo B.")
- (version "0.1")
+ (version "0.2")
  (created 2018-10-17T19:13:41Z)
  (deprecated false)
  (category d0618c29-0436-42da-a388-fdadf7b23892)


### PR DESCRIPTION
The component should not know anything about the package used.

This way, the component and symbol can be re-used for other connectors, for example a screw terminal.